### PR TITLE
Loosen the VSC required version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"c64 assembler kick kickassm kickasss studio"
 	],
 	"engines": {
-		"vscode": "1.57.0"
+		"vscode": "^1.57.0"
 	},
 	"icon": "images/icon.png",
 	"categories": [


### PR DESCRIPTION
It seems that this was an accident, since the previous version did not have the strict versioning requirement.